### PR TITLE
Экранирование символа '-' для MarkdownV2

### DIFF
--- a/send_telegram.py
+++ b/send_telegram.py
@@ -35,6 +35,9 @@ def telegram_send_message(
     ):
     
     try:
+        if parse_mode == "MarkdownV2":
+            text = text.replace('-', '\\-')
+        
         request = urllib.request.Request(
             f"https://api.telegram.org/bot{token}/sendMessage",
             json.dumps(


### PR DESCRIPTION
Исправление ошибки в случае, если в тексте сообщения на отправку в Телеграм в режиме "MarkdownV2" встречается символ `-`:
```json
{"ok":false,"error_code":400,"description":"Bad Request: can't parse entities: Character '-' is reserved and must be escaped with the preceding '\\'"}
```